### PR TITLE
Try to fix stale season state after manual current-season override (fixes #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,174 @@
+# Changelog
+
+## 1.0.35
+
+- **Changed:** Season day counters no longer reset to 0 after a season transition is confirmed. The counter continues to increment (e.g., 8/7, 9/7) as long as the season criteria are met, showing the total number of consecutive qualifying days. The counter resets only when a day no longer meets the criteria.
+- **Fixed:** Prevented unnecessary daily log noise for seasons that have already been confirmed. Transition logic is now skipped entirely for the active season.
+
+## 1.0.34 (beta)
+
+- **Added:** "Set as current season" override option for manual dates.
+- **Added:** One-shot bootstrap overrides are cleared after setup applies them.
+- **Fixed:** Season transition from unknown state now allowed.
+- **Fixed:** Stale season state after manual current-season override (fixes #7).
+- **Fixed:** Reconcile `current_season` / arrival date when automatic logic reaches a season whose arrival date already exists.
+
+## 1.0.33
+
+- **Added:** State-specific icons for the season sensor (snowflake, flower, sun, leaf).
+
+## 1.0.32
+
+- **Changed:** Moved images to `imgs/` subfolder.
+- **Changed:** Updated HACS metadata.
+
+## 1.0.31
+
+- **Fixed:** Bug fixes in sensor logic.
+- **Updated:** Translation strings (en/sv).
+
+## 1.0.30
+
+- **Added:** Screenshot to README.
+- **Updated:** README documentation.
+
+## 1.0.29
+
+- **Changed:** Updated HACS and manifest metadata.
+
+## 1.0.28
+
+- **Changed:** Manifest updates.
+
+## 1.0.27
+
+- **Added:** `hassfest.yaml` validation workflow.
+- **Updated:** README and manifest.
+
+## 1.0.26
+
+- **Added:** `validate.yaml` CI workflow.
+- **Changed:** Moved `hacs.json` to repository root.
+- **Changed:** Sensor updates.
+
+## 1.0.25
+
+- **Refactored:** Config flow to use sectioned history settings.
+
+## 1.0.24
+
+- **Refactored:** Manual season set logic and cleanup flags.
+- **Updated:** README.
+
+## 1.0.23
+
+- **Added:** "Set as current season" option when entering manual dates.
+
+## 1.0.22
+
+- **Refactored:** Manual season date handling.
+- **Updated:** Translations.
+
+## 1.0.21
+
+- **Fixed:** Improved season key mapping in `update_history`.
+
+## 1.0.20
+
+- **Reverted:** Season settings, config flow, and translation changes from 1.0.19.
+
+## 1.0.19
+
+- **Added:** Current season override support.
+- **Added:** Config flow settings for season management.
+- **Changed:** Renamed component.
+- **Updated:** Translations.
+
+## 1.0.18
+
+- **Added:** Green Winter support — allow Autumn → Spring transition (skipping Winter).
+- **Added:** Disclaimer to README.
+
+## 1.0.17
+
+- **Refactored:** Frost date lookup to use long-term statistics.
+
+## 1.0.16
+
+- **Added:** Tracking for days since last frost (`Dagar sedan frost`).
+
+## 1.0.15
+
+- **Added:** Log sensor (`sensor.meteorologisk_arstid_logg`).
+- **Added:** Enhanced logging with logbook integration.
+
+## 1.0.14
+
+- **Fixed:** Typo in sensor.
+- **Updated:** README logo.
+
+## 1.0.13
+
+- **Changed:** Sensors switched to event-driven updates.
+- **Improved:** Logging.
+
+## 1.0.12
+
+- **Improved:** Manual reset and options flow for historical dates.
+
+## 1.0.11
+
+- **Added:** Reset options for historical season dates.
+
+## 1.0.10
+
+- **Updated:** Sensor and translation strings.
+
+## 1.0.9
+
+- **Refactored:** Config flow and improved manual date handling.
+
+## 1.0.8
+
+- **Refactored:** Config and options flow to multi-step dialogs.
+
+## 1.0.7
+
+- **Added:** Reset option for historical season dates.
+
+## 1.0.6.2
+
+- **Fixed:** `OptionsFlowHandler` config entry handling.
+
+## 1.0.6.1
+
+- **Fixed:** Config flow fix.
+
+## 1.0.6
+
+- **Refactored:** Season transition logic.
+- **Updated:** README, HACS metadata, and brand images.
+
+## 1.0.5
+
+- **Improved:** SMHI season logic and translations.
+
+## 1.0.4
+
+- **Added:** Manual date validation and improved config.
+
+## 1.0.3
+
+- **Refactored:** `OptionsFlowHandler` config entry handling.
+
+## 1.0.2
+
+- **Added:** Options flow with manual history dates support.
+
+## 1.0.1
+
+- **Changed:** Moved `sensor.py` to main component directory.
+
+## 1.0.0
+
+- **Initial release:** Meteorological season calculation based on SMHI definitions.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ The main sensor provides:
 - **Höstdygn 0/5:** Progress towards Autumn.
 - **Förra dygnets medeltemp:** The calculated average used for the logic.
 
+> **Note:** After a season is confirmed (e.g., Spring at 7/7), the counter continues to
+> increment as long as the criteria are met (8/7, 9/7, …). This shows the total number
+> of consecutive days that qualify for the current season. The counter resets to 0 only
+> when a day no longer meets the season's criteria.
+
 ## Screenhots
 ![Sensor](./custom_components/smhi_season/imgs/screenshot1.png)
 

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.34.1"
+  "version": "1.0.35"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.34"
+  "version": "1.0.34.1"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.33"
+  "version": "1.0.34"
 }

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -612,7 +612,11 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             days_needed_for_season = self.days_needed[season]
             
             if count >= days_needed_for_season:
-                
+
+                # Already in this season — just let the counter keep climbing
+                if season == self.current_season:
+                    continue
+
                 # Check for Green Winter exception: Allow Autumn -> Spring
                 is_green_winter = (self.current_season == SEASON_AUTUMN and season == SEASON_SPRING)
 
@@ -668,10 +672,6 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                         "[%s] *** SEASON CHANGE ***: Transitioned to '%s'. Arrival date set to %s.",
                         data_date, season, formatted_date
                     )
-                    
-                    self.consecutive_counts[season] = 0
-                else:
-                    self.consecutive_counts[season] = 0
 
         await self._log_info(
             "[%s] Daily check finished. Current Season: %s, Next Target: %s, Transition Counters: %s",

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -33,6 +33,36 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+SET_CURRENT_KEYS = (
+    CONF_SET_CURRENT_SPRING,
+    CONF_SET_CURRENT_SUMMER,
+    CONF_SET_CURRENT_AUTUMN,
+    CONF_SET_CURRENT_WINTER,
+)
+
+
+def _clear_set_current_overrides(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clear one-shot current season overrides after they have been applied."""
+    updated_data = dict(entry.data)
+    updated_options = dict(entry.options)
+    changed = False
+
+    for key in SET_CURRENT_KEYS:
+        if updated_data.get(key):
+            updated_data[key] = False
+            changed = True
+
+        if updated_options.get(key):
+            updated_options[key] = False
+            changed = True
+
+    if changed:
+        hass.config_entries.async_update_entry(
+            entry,
+            data=updated_data,
+            options=updated_options,
+        )
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -61,6 +91,7 @@ async def async_setup_entry(
         SEASON_AUTUMN: config.get(CONF_SET_CURRENT_AUTUMN, False),
         SEASON_WINTER: config.get(CONF_SET_CURRENT_WINTER, False),
     }
+    consumed_current_override = False
 
     # All manually entered dates go to the main sensor, regardless of year
     for season, date_str in date_map.items():
@@ -79,11 +110,15 @@ async def async_setup_entry(
                 
                 # All dates go to main sensor
                 main_sensor.set_manual_arrival_date(season, formatted_date, set_as_current)
+                consumed_current_override = consumed_current_override or set_as_current
                 
             except ValueError:
                 # Log warning to system and logbook (if available)
                 await main_sensor._log_warning("Invalid date format for %s: %s", season, date_str)
                 continue
+
+    if consumed_current_override:
+        _clear_set_current_overrides(hass, entry)
 
     async_add_entities([main_sensor, history_sensor, log_sensor])
 
@@ -266,6 +301,34 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         if self.current_season == SEASON_AUTUMN: return SEASON_WINTER
         return SEASON_WINTER
 
+    def _sync_current_season_from_arrival_dates(self):
+        """Use the most recent known arrival date to correct stale current-season state."""
+        latest_season = None
+        latest_arrival = None
+
+        for season, date_str in self.arrival_dates.items():
+            if not date_str:
+                continue
+
+            parsed_date = self._parse_date_swedish(date_str, date.today().year)
+            if parsed_date is None:
+                continue
+
+            if latest_arrival is None or parsed_date > latest_arrival:
+                latest_arrival = parsed_date
+                latest_season = season
+
+        if latest_season is None:
+            return False
+
+        latest_date_str = self.arrival_dates[latest_season]
+        if self.current_season == latest_season and self.season_arrival_date == latest_date_str:
+            return False
+
+        self.current_season = latest_season
+        self.season_arrival_date = latest_date_str
+        return True
+
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
         
@@ -349,6 +412,13 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             self.async_write_ha_state()
             await self._log_info(
                 "Manually set current season to '%s' with arrival date %s",
+                self.current_season, self.season_arrival_date
+            )
+
+        if self._sync_current_season_from_arrival_dates():
+            self.async_write_ha_state()
+            await self._log_info(
+                "Reconciled current season to '%s' from latest known arrival date %s.",
                 self.current_season, self.season_arrival_date
             )
 
@@ -564,10 +634,19 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                         diff = arrival_dt - existing_dt
                         if diff.days < 180 and diff.days > -180:
                             should_update = False
-                            await self._log_info(
-                                "[%s] *** Season change SKIPPED ***: Criteria met for '%s', but date is already set recently (%s).",
-                                data_date, season, existing_date_str
-                            )
+                            if self.current_season != season or self.season_arrival_date != existing_date_str:
+                                previous_season = self.current_season
+                                self.current_season = season
+                                self.season_arrival_date = existing_date_str
+                                await self._log_info(
+                                    "[%s] Reconciled current season from '%s' to '%s' using existing arrival date %s.",
+                                    data_date, previous_season, season, existing_date_str
+                                )
+                            else:
+                                await self._log_info(
+                                    "[%s] *** Season change SKIPPED ***: Criteria met for '%s', but date is already set recently (%s).",
+                                    data_date, season, existing_date_str
+                                )
                         else:
                             await self._log_info(
                                 "[%s] Existing date for '%s' (%s) is old. Moving to history and updating.",

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -608,24 +608,21 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         self.consecutive_counts = new_counts
         next_season = self.target_season()
 
-        for season, count in self.consecutive_counts.items():
+        # Build the candidate list: only evaluate the logical next season and the
+        # Green Winter exception (Autumn → Spring directly, bypassing Winter).
+        # Iterating all seasons would cause repeated "Transition blocked" log entries
+        # every day for any season whose counter keeps climbing past its threshold.
+        transition_candidates = []
+        if next_season is not None:
+            transition_candidates.append(next_season)
+        if self.current_season == SEASON_AUTUMN and SEASON_SPRING not in transition_candidates:
+            transition_candidates.append(SEASON_SPRING)
+
+        for season in transition_candidates:
+            count = self.consecutive_counts.get(season, 0)
             days_needed_for_season = self.days_needed[season]
-            
+
             if count >= days_needed_for_season:
-
-                # Already in this season — just let the counter keep climbing
-                if season == self.current_season:
-                    continue
-
-                # Check for Green Winter exception: Allow Autumn -> Spring
-                is_green_winter = (self.current_season == SEASON_AUTUMN and season == SEASON_SPRING)
-
-                if next_season is not None and season != next_season and not is_green_winter:
-                    await self._log_info(
-                        "[%s] Criteria met for '%s' (%d/%d), but logical next season is '%s'. Transition blocked.",
-                        data_date, season, count, days_needed_for_season, next_season
-                    )
-                    continue 
                 
                 arrival_dt = data_date - timedelta(days=days_needed_for_season - 1)
                 

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -608,21 +608,24 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         self.consecutive_counts = new_counts
         next_season = self.target_season()
 
-        # Build the candidate list: only evaluate the logical next season and the
-        # Green Winter exception (Autumn → Spring directly, bypassing Winter).
-        # Iterating all seasons would cause repeated "Transition blocked" log entries
-        # every day for any season whose counter keeps climbing past its threshold.
-        transition_candidates = []
-        if next_season is not None:
-            transition_candidates.append(next_season)
-        if self.current_season == SEASON_AUTUMN and SEASON_SPRING not in transition_candidates:
-            transition_candidates.append(SEASON_SPRING)
-
-        for season in transition_candidates:
-            count = self.consecutive_counts.get(season, 0)
+        for season, count in self.consecutive_counts.items():
             days_needed_for_season = self.days_needed[season]
-
+            
             if count >= days_needed_for_season:
+
+                # Already in this season — just let the counter keep climbing
+                if season == self.current_season:
+                    continue
+
+                # Check for Green Winter exception: Allow Autumn -> Spring
+                is_green_winter = (self.current_season == SEASON_AUTUMN and season == SEASON_SPRING)
+
+                if next_season is not None and season != next_season and not is_green_winter:
+                    await self._log_info(
+                        "[%s] Criteria met for '%s' (%d/%d), but logical next season is '%s'. Transition blocked.",
+                        data_date, season, count, days_needed_for_season, next_season
+                    )
+                    continue 
                 
                 arrival_dt = data_date - timedelta(days=days_needed_for_season - 1)
                 

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -299,7 +299,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         if self.current_season == SEASON_SPRING: return SEASON_SUMMER
         if self.current_season == SEASON_SUMMER: return SEASON_AUTUMN
         if self.current_season == SEASON_AUTUMN: return SEASON_WINTER
-        return SEASON_WINTER
+        return None
 
     def _sync_current_season_from_arrival_dates(self):
         """Use the most recent known arrival date to correct stale current-season state."""
@@ -616,7 +616,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                 # Check for Green Winter exception: Allow Autumn -> Spring
                 is_green_winter = (self.current_season == SEASON_AUTUMN and season == SEASON_SPRING)
 
-                if season != next_season and not is_green_winter:
+                if next_season is not None and season != next_season and not is_green_winter:
                     await self._log_info(
                         "[%s] Criteria met for '%s' (%d/%d), but logical next season is '%s'. Transition blocked.",
                         data_date, season, count, days_needed_for_season, next_season

--- a/custom_components/smhi_season/translations/en.json
+++ b/custom_components/smhi_season/translations/en.json
@@ -20,7 +20,7 @@
             },
             "history_settings": {
                 "title": "Set Past Season Dates (Optional)",
-                "description": "Enter dates for seasons that have already occurred. These dates will be displayed in the main sensor's attributes (sensor.meteorologisk_arstid).\n\nCheck the link to SMHI in README for how to get previous season dates.\n\n**Definitions:**\n* **Spring:** > 0°C for 7 consecutive days (earliest Feb 15)\n* **Summer:** ≥ 10°C for 5 consecutive days\n* **Autumn:** < 10°C for 5 consecutive days (earliest Aug 1)\n* **Winter:** ≤ 0°C for 5 consecutive days\n\n**Note:** When a new season arrives automatically, the old date will be moved to the history sensor (sensor.meteorologisk_arstid_historisk).",
+                "description": "Enter dates for seasons that have already occurred. These dates will be displayed in the main sensor's attributes (sensor.meteorologisk_arstid).\n\nCheck the link to SMHI in README for how to get previous season dates.\n\n**Definitions:**\n* **Spring:** > 0°C for 7 consecutive days (earliest Feb 15)\n* **Summer:** ≥ 10°C for 5 consecutive days\n* **Autumn:** < 10°C for 5 consecutive days (earliest Aug 1)\n* **Winter:** ≤ 0°C for 5 consecutive days\n\n**Note:** When a new season arrives automatically, the old date will be moved to the history sensor (sensor.meteorologisk_arstid_historisk). \"Set as current season\" is a one-time override and is cleared automatically after it has been applied.",
                 "sections": {
                     "section_spring": {
                         "name": "Spring",
@@ -82,7 +82,7 @@
             },
             "history_settings": {
                 "title": "Set Past Season Dates (Optional)",
-                "description": "Enter dates for seasons that have already occurred. These dates will be displayed in the main sensor's attributes (sensor.meteorologisk_arstid).\n\nCheck the link to SMHI in README for previous season dates.\n\n**Definitions:**\n* **Spring:** > 0°C for 7 consecutive days (earliest Feb 15)\n* **Summer:** ≥ 10°C for 5 consecutive days\n* **Autumn:** < 10°C for 5 consecutive days (earliest Aug 1)\n* **Winter:** ≤ 0°C for 5 consecutive days\n\n**Note:** When a new season arrives automatically, the old date will be moved to the history sensor (sensor.meteorologisk_arstid_historisk).",
+                "description": "Enter dates for seasons that have already occurred. These dates will be displayed in the main sensor's attributes (sensor.meteorologisk_arstid).\n\nCheck the link to SMHI in README for previous season dates.\n\n**Definitions:**\n* **Spring:** > 0°C for 7 consecutive days (earliest Feb 15)\n* **Summer:** ≥ 10°C for 5 consecutive days\n* **Autumn:** < 10°C for 5 consecutive days (earliest Aug 1)\n* **Winter:** ≤ 0°C for 5 consecutive days\n\n**Note:** When a new season arrives automatically, the old date will be moved to the history sensor (sensor.meteorologisk_arstid_historisk). \"Set as current season\" is a one-time override and is cleared automatically after it has been applied.",
                 "sections": {
                     "section_spring": {
                         "name": "Spring",

--- a/custom_components/smhi_season/translations/sv.json
+++ b/custom_components/smhi_season/translations/sv.json
@@ -20,7 +20,7 @@
             },
             "history_settings": {
                 "title": "Ange datum för förflutna årstider (Valfritt)",
-                "description": "Ange datum för årstider som redan inträffat. Dessa datum kommer att visas i huvudsensorns attribut (sensor.meteorologisk_arstid).\n\nKontrollera länken till SMHI i README för hur man får fram tidigare årstidsdatum.\n\n**Definitioner:**\n* **Vår:** > 0°C i 7 dagar (tidigast 15 feb)\n* **Sommar:** ≥ 10°C i 5 dagar\n* **Höst:** < 10°C i 5 dagar (tidigast 1 aug)\n* **Vinter:** ≤ 0°C i 5 dagar\n\n**OBS:** När en ny årstid inträffar automatiskt kommer det gamla datumet att flyttas till historiksensorn (sensor.meteorologisk_arstid_historisk).",
+                "description": "Ange datum för årstider som redan inträffat. Dessa datum kommer att visas i huvudsensorns attribut (sensor.meteorologisk_arstid).\n\nKontrollera länken till SMHI i README för hur man får fram tidigare årstidsdatum.\n\n**Definitioner:**\n* **Vår:** > 0°C i 7 dagar (tidigast 15 feb)\n* **Sommar:** ≥ 10°C i 5 dagar\n* **Höst:** < 10°C i 5 dagar (tidigast 1 aug)\n* **Vinter:** ≤ 0°C i 5 dagar\n\n**OBS:** När en ny årstid inträffar automatiskt kommer det gamla datumet att flyttas till historiksensorn (sensor.meteorologisk_arstid_historisk). \"Ange som nuvarande årstid\" är en engångsåtgärd och återställs automatiskt efter att den har använts.",
                 "sections": {
                     "section_spring": {
                         "name": "Vår",
@@ -82,7 +82,7 @@
             },
             "history_settings": {
                 "title": "Ange datum för förflutna årstider (Valfritt)",
-                "description": "Ange datum för årstider som redan inträffat. Dessa datum kommer att visas i huvudsensorns attribut (sensor.meteorologisk_arstid).\n\nKontrollera länken till SMHI i README för tidigare årstidsdatum.\n\n**Definitioner:**\n* **Vår:** > 0°C i 7 dagar (tidigast 15 feb)\n* **Sommar:** ≥ 10°C i 5 dagar\n* **Höst:** < 10°C i 5 dagar (tidigast 1 aug)\n* **Vinter:** ≤ 0°C i 5 dagar\n\n**OBS:** När en ny årstid inträffar automatiskt kommer det gamla datumet att flyttas till historiksensorn (sensor.meteorologisk_arstid_historisk).",
+                "description": "Ange datum för årstider som redan inträffat. Dessa datum kommer att visas i huvudsensorns attribut (sensor.meteorologisk_arstid).\n\nKontrollera länken till SMHI i README för tidigare årstidsdatum.\n\n**Definitioner:**\n* **Vår:** > 0°C i 7 dagar (tidigast 15 feb)\n* **Sommar:** ≥ 10°C i 5 dagar\n* **Höst:** < 10°C i 5 dagar (tidigast 1 aug)\n* **Vinter:** ≤ 0°C i 5 dagar\n\n**OBS:** När en ny årstid inträffar automatiskt kommer det gamla datumet att flyttas till historiksensorn (sensor.meteorologisk_arstid_historisk). \"Ange som nuvarande årstid\" är en engångsåtgärd och återställs automatiskt efter att den har använts.",
                 "sections": {
                     "section_spring": {
                         "name": "Vår",


### PR DESCRIPTION
## Summary
This PR fixes a state inconsistency where the sensor could stay on Vinter even when Vår had already been detected and stored.

## Problem
Issue #7 reported cases where:
- Vår criteria had been met (`Vårdygn` complete)
- `Vårens ankomstdatum` was already set
- but sensor state still showed Vinter

This happened when a manual “set current season” override remained effectively sticky, and later automatic checks skipped updating state if the season date was already present.

## What changed
- Treat `set_current_*` flags as one-time overrides:
  - Apply during setup
  - Then clear them in config entry data/options so they do not keep forcing state on reload
- Add startup reconciliation:
  - Derive current season from the latest known arrival date when restored state is stale
- Improve automatic transition handling:
  - If criteria are met and arrival date already exists for the same cycle, reconcile `current_season`/`Ankomstdatum` instead of only skipping
- Update EN/SV flow text:
  - Clarify that “Set as current season” is a one-time action

## Files changed
- `custom_components/smhi_season/sensor.py`
- `custom_components/smhi_season/translations/en.json`
- `custom_components/smhi_season/translations/sv.json`

## Result
The sensor now self-corrects to the proper season (e.g. Vår) when valid arrival data exists, and manual current-season selections no longer persist unintentionally across reloads.

## Related
- Fixes #7
```