### PR TITLE
Restrict transition-check loop to next_season only to suppress log noise

### DIFF
--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -608,24 +608,21 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         self.consecutive_counts = new_counts
         next_season = self.target_season()
 
-        for season, count in self.consecutive_counts.items():
+        # Build the candidate list: only evaluate the logical next season and the
+        # Green Winter exception (Autumn → Spring directly, bypassing Winter).
+        # Iterating all seasons would cause repeated "Transition blocked" log entries
+        # every day for any season whose counter keeps climbing past its threshold.
+        transition_candidates = []
+        if next_season is not None:
+            transition_candidates.append(next_season)
+        if self.current_season == SEASON_AUTUMN and SEASON_SPRING not in transition_candidates:
+            transition_candidates.append(SEASON_SPRING)
+
+        for season in transition_candidates:
+            count = self.consecutive_counts.get(season, 0)
             days_needed_for_season = self.days_needed[season]
-            
+
             if count >= days_needed_for_season:
-
-                # Already in this season — just let the counter keep climbing
-                if season == self.current_season:
-                    continue
-
-                # Check for Green Winter exception: Allow Autumn -> Spring
-                is_green_winter = (self.current_season == SEASON_AUTUMN and season == SEASON_SPRING)
-
-                if next_season is not None and season != next_season and not is_green_winter:
-                    await self._log_info(
-                        "[%s] Criteria met for '%s' (%d/%d), but logical next season is '%s'. Transition blocked.",
-                        data_date, season, count, days_needed_for_season, next_season
-                    )
-                    continue 
                 
                 arrival_dt = data_date - timedelta(days=days_needed_for_season - 1)
                 


### PR DESCRIPTION
## Summary

Restrict the transition-check loop to only evaluate `next_season` (the logical next season from the current one) plus the Green Winter exception (Autumn → Spring). This prevents repeated "Transition blocked" log entries that were emitted every day for any season whose counter kept climbing past its threshold (e.g., Spring at 8/7, 9/7…).

The counting loop itself still runs over all seasons so counters continue to accumulate correctly.

## Changes

- `custom_components/smhi_season/sensor.py`: Refactored `_process_smhi_logic()` to build a `transition_candidates` list containing only `next_season` and (if applicable) the Green Winter candidate, instead of iterating all seasons.

## Related

- Split out from PR #8 per review feedback