### PR TITLE
Add debug entities for simulation and simulate days and temperatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.36
+
+- **Added:** Debug entities (Date, Temp, and Step Day button) for simulating days and temperatures. This helps with testing algorithm logic without waiting for real-time days.
+- **Fixed:** Resolves issue #11 (https://github.com/droidgren/smhi_season/issues/11).
+
 ## 1.0.35
 
 - **Changed:** Season day counters no longer reset to 0 after a season transition is confirmed. The counter continues to increment (e.g., 8/7, 9/7) as long as the season criteria are met, showing the total number of consecutive qualifying days. The counter resets only when a day no longer meets the criteria.

--- a/README.md
+++ b/README.md
@@ -60,5 +60,20 @@ The main sensor provides:
 ## Screenhots
 ![Sensor](./custom_components/smhi_season/imgs/screenshot1.png)
 
+## Debug Entities
+For testing and simulation, you can enable Debug Entities through the integration's configuration choices (Options). When enabled, three new entities are provided:
+1. **Debug Date**: Lets you manually set a mock date.
+2. **Debug Temp**: Lets you manually set the daily average temperature for simulation.
+3. **Debug Step Day (Button)**: Pressing this button will process the mock date and temperature as if the day has just ended.
+
+This makes it easy to simulate consecutive days of specific temperatures and quickly verify season transitions.
+
+## Changelog
+*See the full history in CHANGELOG.md.*
+
+### 1.36
+- **Added:** Debug entities for simulating days and temperatures to test season transitions manually.
+- **Fixed:** Resolves issue #11.
+
 ## Disclaimer
 This project is an independent custom integration and is **not** affiliated with, endorsed by, or connected to **SMHI** (Swedish Meteorological and Hydrological Institute) in any way. It simply uses their public meteorological definitions to calculate seasons.

--- a/custom_components/smhi_season/__init__.py
+++ b/custom_components/smhi_season/__init__.py
@@ -7,11 +7,12 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.DATE, Platform.NUMBER]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SMHI Season from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {}
     
     # Set up the platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/smhi_season/button.py
+++ b/custom_components/smhi_season/button.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_ENABLE_DEBUG_ENTITIES
 from homeassistant.const import EntityCategory
 
 
@@ -17,6 +17,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the debug step button."""
+    enable_debug = entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, entry.data.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+    if not enable_debug:
+        return
+
     button = SmhiDebugStep(entry)
     
     if entry.entry_id in hass.data.get(DOMAIN, {}):

--- a/custom_components/smhi_season/button.py
+++ b/custom_components/smhi_season/button.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from homeassistant.const import EntityCategory
 
 
 async def async_setup_entry(
@@ -30,6 +31,7 @@ class SmhiDebugStep(ButtonEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the button."""

--- a/custom_components/smhi_season/button.py
+++ b/custom_components/smhi_season/button.py
@@ -31,7 +31,7 @@ class SmhiDebugStep(ButtonEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the button."""

--- a/custom_components/smhi_season/button.py
+++ b/custom_components/smhi_season/button.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import datetime
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the debug step button."""
+    button = SmhiDebugStep(entry)
+    
+    if entry.entry_id in hass.data.get(DOMAIN, {}):
+        hass.data[DOMAIN][entry.entry_id]["debug_step"] = button
+
+    async_add_entities([button])
+
+
+class SmhiDebugStep(ButtonEntity):
+    """Button to manually advance the day for debugging."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the button."""
+        self._entry = entry
+        self._attr_name = "Debug Step Day"
+        self._attr_unique_id = f"{entry.entry_id}_debug_step_day"
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        shared_data = self.hass.data.get(DOMAIN, {}).get(self._entry.entry_id, {})
+        
+        main_sensor = shared_data.get("main_sensor")
+        debug_date_entity = shared_data.get("debug_date")
+        debug_temp_entity = shared_data.get("debug_temp")
+
+        if not main_sensor or not debug_date_entity or not debug_temp_entity:
+            return  # The other debug entities must also be active
+
+        current_date_val = debug_date_entity.state
+        if current_date_val in (None, "unknown", "unavailable"):
+            return
+
+        current_temp_val = debug_temp_entity.state
+        if current_temp_val in (None, "unknown", "unavailable"):
+            return
+
+        # Execute debug step
+        debug_date_dt = datetime.date.fromisoformat(current_date_val)
+        await main_sensor.process_debug_step(debug_date_dt, current_temp_val)
+
+        # Advance the date by 1 day automatically
+        new_date = debug_date_dt + datetime.timedelta(days=1)
+        debug_date_entity.set_date(new_date)

--- a/custom_components/smhi_season/config_flow.py
+++ b/custom_components/smhi_season/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import selector
 from .const import (
     DOMAIN, 
     CONF_TEMPERATURE_SENSOR,
+    CONF_ENABLE_DEBUG_ENTITIES,
     CONF_HISTORY_SPRING,
     CONF_HISTORY_SUMMER,
     CONF_HISTORY_AUTUMN,
@@ -62,6 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_TEMPERATURE_SENSOR): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", device_class="temperature")
             ),
+            vol.Optional(CONF_ENABLE_DEBUG_ENTITIES, default=False): bool,
         })
 
         return self.async_show_form(
@@ -219,6 +221,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(CONF_TEMPERATURE_SENSOR, default=defaults.get(CONF_TEMPERATURE_SENSOR)): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", device_class="temperature")
             ),
+            vol.Optional(CONF_ENABLE_DEBUG_ENTITIES, default=defaults.get(CONF_ENABLE_DEBUG_ENTITIES, False)): bool,
         })
 
         return self.async_show_form(

--- a/custom_components/smhi_season/const.py
+++ b/custom_components/smhi_season/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "smhi_season"
 CONF_TEMPERATURE_SENSOR = "temperature_sensor"
+CONF_ENABLE_DEBUG_ENTITIES = "enable_debug_entities"
 
 # Configuration constants for historical dates
 CONF_HISTORY_SPRING = "history_spring"

--- a/custom_components/smhi_season/date.py
+++ b/custom_components/smhi_season/date.py
@@ -31,7 +31,7 @@ class SmhiDebugDate(DateEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize."""

--- a/custom_components/smhi_season/date.py
+++ b/custom_components/smhi_season/date.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_ENABLE_DEBUG_ENTITIES
 from homeassistant.const import EntityCategory
 
 
@@ -17,6 +17,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the debug date entity."""
+    enable_debug = entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, entry.data.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+    if not enable_debug:
+        return
+
     date_entity = SmhiDebugDate(entry)
 
     if entry.entry_id in hass.data.get(DOMAIN, {}):

--- a/custom_components/smhi_season/date.py
+++ b/custom_components/smhi_season/date.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from homeassistant.const import EntityCategory
 
 
 async def async_setup_entry(
@@ -30,6 +31,7 @@ class SmhiDebugDate(DateEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize."""

--- a/custom_components/smhi_season/date.py
+++ b/custom_components/smhi_season/date.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import datetime
+
+from homeassistant.components.date import DateEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the debug date entity."""
+    date_entity = SmhiDebugDate(entry)
+
+    if entry.entry_id in hass.data.get(DOMAIN, {}):
+        hass.data[DOMAIN][entry.entry_id]["debug_date"] = date_entity
+
+    async_add_entities([date_entity])
+
+
+class SmhiDebugDate(DateEntity):
+    """Date entity to set the simulated date for debugging."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize."""
+        self._entry = entry
+        self._attr_name = "Debug Date"
+        self._attr_unique_id = f"{entry.entry_id}_debug_date"
+        self._attr_native_value = datetime.date.today()
+
+    async def async_set_value(self, value: datetime.date) -> None:
+        """Update the date via UI directly."""
+        self.set_date(value)
+
+    def set_date(self, value: datetime.date) -> None:
+        """Internal method to update the date."""
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta7"
+  "version": "1.0.36-beta8"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta9"
+  "version": "1.0.36-beta10"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta4"
+  "version": "1.0.36-beta5"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.35"
+  "version": "1.0.36-beta2"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta2"
+  "version": "1.0.36-beta3"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta6"
+  "version": "1.0.36-beta7"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta3"
+  "version": "1.0.36-beta4"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta5"
+  "version": "1.0.36-beta6"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta8"
+  "version": "1.0.36-beta9"
 }

--- a/custom_components/smhi_season/manifest.json
+++ b/custom_components/smhi_season/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/droidgren/smhi_season/issues",
   "requirements": [],
-  "version": "1.0.36-beta10"
+  "version": "1.36"
 }

--- a/custom_components/smhi_season/number.py
+++ b/custom_components/smhi_season/number.py
@@ -29,7 +29,7 @@ class SmhiDebugTemp(NumberEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_native_min_value = -50.0
     _attr_native_max_value = 50.0
     _attr_native_step = 0.1

--- a/custom_components/smhi_season/number.py
+++ b/custom_components/smhi_season/number.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.const import UnitOfTemperature
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the debug temperature entity."""
+    number_entity = SmhiDebugTemp(entry)
+
+    if entry.entry_id in hass.data.get(DOMAIN, {}):
+        hass.data[DOMAIN][entry.entry_id]["debug_temp"] = number_entity
+
+    async_add_entities([number_entity])
+
+
+class SmhiDebugTemp(NumberEntity):
+    """Number entity to set the simulated average temperature for debugging."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+    _attr_native_min_value = -50.0
+    _attr_native_max_value = 50.0
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize."""
+        self._entry = entry
+        self._attr_name = "Debug Avg Temp"
+        self._attr_unique_id = f"{entry.entry_id}_debug_avg_temp"
+        self._attr_native_value = 10.0
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/custom_components/smhi_season/number.py
+++ b/custom_components/smhi_season/number.py
@@ -4,7 +4,7 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, EntityCategory
 
 from .const import DOMAIN
 
@@ -29,6 +29,7 @@ class SmhiDebugTemp(NumberEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_min_value = -50.0
     _attr_native_max_value = 50.0
     _attr_native_step = 0.1

--- a/custom_components/smhi_season/number.py
+++ b/custom_components/smhi_season/number.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.const import UnitOfTemperature, EntityCategory
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_ENABLE_DEBUG_ENTITIES
 
 
 async def async_setup_entry(
@@ -15,6 +15,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the debug temperature entity."""
+    enable_debug = entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, entry.data.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+    if not enable_debug:
+        return
+
     number_entity = SmhiDebugTemp(entry)
 
     if entry.entry_id in hass.data.get(DOMAIN, {}):

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -304,6 +304,13 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             "config_set_winter": config.get(CONF_SET_CURRENT_WINTER, False),
             "manual_flags": self._manual_flags
         }
+        
+        # Hide internal config variables inside a single attribute
+        internal_config = {}
+        for key in ["config_history_spring", "config_history_summer", "config_history_autumn", "config_history_winter", 
+                    "config_set_spring", "config_set_summer", "config_set_autumn", "config_set_winter", "manual_flags"]:
+            internal_config[key] = attrs.pop(key)
+        attrs["_internal_config_state"] = internal_config
         return attrs
 
     def target_season(self):
@@ -347,6 +354,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         # First, restore from saved state if available
         if (state := await self.async_get_last_state()) is not None:
             # Check for stale "set_as_current" configurations on reboot
+            internal_config = state.attributes.get("_internal_config_state", {})
             config = {**self._entry.data, **self._entry.options}
             stale_set_map = {
                 SEASON_SPRING: ("config_set_spring", CONF_SET_CURRENT_SPRING),
@@ -357,7 +365,9 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             is_stale_set = False
             for season_key, (attr_key, conf_key) in stale_set_map.items():
                 if config.get(conf_key, False):
-                    if state.attributes.get(attr_key) == True:
+                    # Check in new internal_config first, fallback to root attributes
+                    last_val = internal_config.get(attr_key, state.attributes.get(attr_key))
+                    if last_val == True:
                         is_stale_set = True
             
             if is_stale_set and self._pending_state_write:
@@ -401,7 +411,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                     self.days_since_frost = None
 
             # Restore Manual Flags
-            saved_flags = state.attributes.get("manual_flags", {})
+            saved_flags = internal_config.get("manual_flags", state.attributes.get("manual_flags", {}))
             has_history = len(saved_flags) > 0 
             
             if saved_flags:
@@ -410,7 +420,6 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                         self._manual_flags[s] = saved_flags[s]
 
             # Check for stale configurations (reboot vs fresh option change)
-            config = {**self._entry.data, **self._entry.options}
             stale_keys_map = {
                 SEASON_SPRING: ("Vårens ankomstdatum", "config_history_spring", CONF_HISTORY_SPRING),
                 SEASON_SUMMER: ("Sommarens ankomstdatum", "config_history_summer", CONF_HISTORY_SUMMER),
@@ -420,7 +429,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             for s in list(self._configured_seasons):
                 if s in stale_keys_map:
                     attr_name, config_attr_name, conf_key = stale_keys_map[s]
-                    last_config_val = state.attributes.get(config_attr_name)
+                    last_config_val = internal_config.get(config_attr_name, state.attributes.get(config_attr_name))
                     current_config_val = config.get(conf_key)
                     
                     if last_config_val is not None and last_config_val == current_config_val:

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -280,6 +280,7 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         def get_count(season, limit):
             return f"{self.consecutive_counts.get(season, 0)}/{limit}"
 
+        config = {**self._entry.data, **self._entry.options}
         attrs = {
             "Ankomstdatum": self.season_arrival_date,
             "Förra dygnets medeltemp": f"{self.daily_avg_temp:.1f}°C" if self.daily_avg_temp is not None else None,
@@ -293,6 +294,14 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
             "Sommarens ankomstdatum": self.arrival_dates[SEASON_SUMMER],
             "Höstens ankomstdatum": self.arrival_dates[SEASON_AUTUMN],
             "Vinterns ankomstdatum": self.arrival_dates[SEASON_WINTER],
+            "config_history_spring": config.get(CONF_HISTORY_SPRING),
+            "config_history_summer": config.get(CONF_HISTORY_SUMMER),
+            "config_history_autumn": config.get(CONF_HISTORY_AUTUMN),
+            "config_history_winter": config.get(CONF_HISTORY_WINTER),
+            "config_set_spring": config.get(CONF_SET_CURRENT_SPRING, False),
+            "config_set_summer": config.get(CONF_SET_CURRENT_SUMMER, False),
+            "config_set_autumn": config.get(CONF_SET_CURRENT_AUTUMN, False),
+            "config_set_winter": config.get(CONF_SET_CURRENT_WINTER, False),
             "manual_flags": self._manual_flags
         }
         return attrs
@@ -337,6 +346,23 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
         
         # First, restore from saved state if available
         if (state := await self.async_get_last_state()) is not None:
+            # Check for stale "set_as_current" configurations on reboot
+            config = {**self._entry.data, **self._entry.options}
+            stale_set_map = {
+                SEASON_SPRING: ("config_set_spring", CONF_SET_CURRENT_SPRING),
+                SEASON_SUMMER: ("config_set_summer", CONF_SET_CURRENT_SUMMER),
+                SEASON_AUTUMN: ("config_set_autumn", CONF_SET_CURRENT_AUTUMN),
+                SEASON_WINTER: ("config_set_winter", CONF_SET_CURRENT_WINTER),
+            }
+            is_stale_set = False
+            for season_key, (attr_key, conf_key) in stale_set_map.items():
+                if config.get(conf_key, False):
+                    if state.attributes.get(attr_key) == True:
+                        is_stale_set = True
+            
+            if is_stale_set and self._pending_state_write:
+                self._pending_state_write = False
+                
             # Only restore if we don't have pending changes from config
             if not self._pending_state_write:
                 self.current_season = state.state
@@ -383,6 +409,28 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                     if s not in self._configured_seasons and s in saved_flags:
                         self._manual_flags[s] = saved_flags[s]
 
+            # Check for stale configurations (reboot vs fresh option change)
+            config = {**self._entry.data, **self._entry.options}
+            stale_keys_map = {
+                SEASON_SPRING: ("Vårens ankomstdatum", "config_history_spring", CONF_HISTORY_SPRING),
+                SEASON_SUMMER: ("Sommarens ankomstdatum", "config_history_summer", CONF_HISTORY_SUMMER),
+                SEASON_AUTUMN: ("Höstens ankomstdatum", "config_history_autumn", CONF_HISTORY_AUTUMN),
+                SEASON_WINTER: ("Vinterns ankomstdatum", "config_history_winter", CONF_HISTORY_WINTER),
+            }
+            for s in list(self._configured_seasons):
+                if s in stale_keys_map:
+                    attr_name, config_attr_name, conf_key = stale_keys_map[s]
+                    last_config_val = state.attributes.get(config_attr_name)
+                    current_config_val = config.get(conf_key)
+                    
+                    if last_config_val is not None and last_config_val == current_config_val:
+                        # The config hasn't changed since the state was saved!
+                        # Treat this as a reboot: restore dynamic arrival date from state.
+                        saved_date = state.attributes.get(attr_name)
+                        if saved_date is not None:
+                             self.arrival_dates[s] = saved_date
+                        self._configured_seasons.discard(s)
+
             # Restore Dates Logic
             for s in self.arrival_dates.keys():
                 if s in self._configured_seasons:
@@ -410,15 +458,17 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
                         self._manual_flags[s] = False
 
         # If we have a pending state write (from "set as current" checkbox), write it now
+        pending_write_done = False
         if self._pending_state_write:
             self._pending_state_write = False
+            pending_write_done = True
             self.async_write_ha_state()
             await self._log_info(
                 "Manually set current season to '%s' with arrival date %s",
                 self.current_season, self.season_arrival_date
             )
 
-        if self._sync_current_season_from_arrival_dates():
+        if not pending_write_done and self._sync_current_season_from_arrival_dates():
             self.async_write_ha_state()
             await self._log_info(
                 "Reconciled current season to '%s' from latest known arrival date %s.",
@@ -494,21 +544,31 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
 
     async def _send_to_logbook(self, message, *args):
         """Format message and send to logbook service if log sensor is available."""
-        if self._log_sensor and self._log_sensor.hass and self._log_sensor.entity_id:
+        if self._log_sensor:
             try:
                 formatted_message = message % args
             except Exception:
                 formatted_message = message
             
             self._log_sensor.update_timestamp()
-            await self.hass.services.async_call(
-                "logbook", "log",
-                {
-                    "name": self._log_sensor.name,
-                    "message": formatted_message,
-                    "entity_id": self._log_sensor.entity_id,
-                }
-            )
+            
+            entity_id = self._log_sensor.entity_id
+            name = self._log_sensor.name
+            
+            # Fallback if log sensor is not yet fully initialized by HA
+            if not entity_id:
+                entity_id = self.entity_id
+                name = self.name
+                
+            if self.hass and entity_id:
+                await self.hass.services.async_call(
+                    "logbook", "log",
+                    {
+                        "name": name,
+                        "message": formatted_message,
+                        "entity_id": entity_id,
+                    }
+                )
 
     # --- Main Logic ---
 

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -78,6 +78,9 @@ async def async_setup_entry(
     log_sensor = SmhiLogSensor(entry.entry_id)
     main_sensor = SmhiSeasonSensor(hass, entry, temp_sensor_id, history_sensor, log_sensor)
 
+    hass.data[DOMAIN][entry.entry_id]["main_sensor"] = main_sensor
+
+
     date_map = {
         SEASON_SPRING: config.get(CONF_HISTORY_SPRING),
         SEASON_SUMMER: config.get(CONF_HISTORY_SUMMER),
@@ -509,7 +512,28 @@ class SmhiSeasonSensor(RestoreSensor, SensorEntity):
 
     # --- Main Logic ---
 
+    async def process_debug_step(self, debug_date, debug_temp):
+        """Process a simulated day instead of reading recorder data."""
+        self.daily_avg_temp = float(debug_temp)
+        min_temp = self.daily_avg_temp # Assume same as average for testing
+        
+        if min_temp <= 0.0:
+            self.days_since_frost = 0
+        elif self.days_since_frost is not None:
+            self.days_since_frost += 1
+
+        self.last_update = debug_date.isoformat()
+        
+        # 'now' internally acts as tomorrow when evaluating 'yesterday'
+        # so we pass debug_date as yesterday's date
+        await self._process_smhi_logic(self.daily_avg_temp, debug_date + timedelta(days=1))
+        self.async_write_ha_state()
+
     async def _daily_check(self, now):
+        shared_data = self.hass.data.get(DOMAIN, {}).get(self._entry.entry_id, {})
+        if shared_data.get("debug_step") and shared_data.get("debug_date") and shared_data.get("debug_temp"):
+            return # Skip normal logic
+
         yesterday = now - timedelta(days=1)
         start_time = yesterday.replace(hour=0, minute=0, second=0, microsecond=0)
         end_time = yesterday.replace(hour=23, minute=59, second=59, microsecond=999999)

--- a/custom_components/smhi_season/sensor.py
+++ b/custom_components/smhi_season/sensor.py
@@ -141,7 +141,8 @@ class SmhiLogSensor(SensorEntity):
     def update_timestamp(self):
         """Update the state to show when the last log happened."""
         self._attr_native_value = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.async_write_ha_state()
+        if self.hass is not None:
+            self.async_write_ha_state()
 
 
 class SmhiHistorySensor(RestoreSensor, SensorEntity):

--- a/custom_components/smhi_season/translations/en.json
+++ b/custom_components/smhi_season/translations/en.json
@@ -5,10 +5,12 @@
                 "title": "Meteorological Season",
                 "description": "Step 1: Select sensor.",
                 "data": {
-                    "temperature_sensor": "Temperature Sensor (Outdoor)"
+                    "temperature_sensor": "Temperature Sensor (Outdoor)",
+                    "enable_debug_entities": "Enable debug entities"
                 },
                 "data_description": {
-                    "temperature_sensor": "Select the outdoor temperature sensor to use for season calculations."
+                    "temperature_sensor": "Select the outdoor temperature sensor to use for season calculations.",
+                    "enable_debug_entities": "Enable debug entities for date and temperature testing."
                 }
             },
             "menu": {
@@ -74,10 +76,12 @@
             "sensor_settings": {
                 "title": "Sensor Settings",
                 "data": {
-                    "temperature_sensor": "Temperature Sensor (Outdoor)"
+                    "temperature_sensor": "Temperature Sensor (Outdoor)",
+                    "enable_debug_entities": "Enable debug entities"
                 },
                 "data_description": {
-                    "temperature_sensor": "Select the outdoor temperature sensor to use for season calculations."
+                    "temperature_sensor": "Select the outdoor temperature sensor to use for season calculations.",
+                    "enable_debug_entities": "Enable hidden debug entities for date and temperature testing."
                 }
             },
             "history_settings": {

--- a/custom_components/smhi_season/translations/sv.json
+++ b/custom_components/smhi_season/translations/sv.json
@@ -5,10 +5,12 @@
                 "title": "Meteorologisk Årstid",
                 "description": "Steg 1: Välj sensor.",
                 "data": {
-                    "temperature_sensor": "Temperatursensor (Utomhus)"
+                    "temperature_sensor": "Temperatursensor (Utomhus)",
+                    "enable_debug_entities": "Aktivera debugg-entiteter"
                 },
                 "data_description": {
-                    "temperature_sensor": "Välj utomhustemperatursensorn som ska användas för årstidsberäkningar."
+                    "temperature_sensor": "Välj utomhustemperatursensorn som ska användas för årstidsberäkningar.",
+                    "enable_debug_entities": "Aktivera debugg-entiteter för datum- och temperaturtestning."
                 }
             },
             "menu": {
@@ -74,10 +76,12 @@
             "sensor_settings": {
                 "title": "Inställningar för sensor",
                 "data": {
-                    "temperature_sensor": "Temperatursensor (Utomhus)"
+                    "temperature_sensor": "Temperatursensor (Utomhus)",
+                    "enable_debug_entities": "Aktivera debug-entiteter"
                 },
                 "data_description": {
-                    "temperature_sensor": "Välj utomhustemperatursensorn som ska användas för årstidsberäkningar."
+                    "temperature_sensor": "Välj utomhustemperatursensorn som ska användas för årstidsberäkningar.",
+                    "enable_debug_entities": "Aktivera dolda debug-entiteter för datum- och temperaturtestning."
                 }
             },
             "history_settings": {


### PR DESCRIPTION
This pull request fixes #11 and adds debug entities to simulate date transitions and temperature logic faster without waiting for a full 24-hour cycle. 

They are disabled by default. When enabled manually, they override the normal 00:00 trigger.

**Features added:**
- `meteorologisk_arstid_debug_step_day`: Button to step time and simulate processing for a given day.
- `meteorologisk_arstid_debug_date`: Date entity to manually specify the target date.
- `meteorologisk_arstid_debug_avg_temp`: Number entity to manually dial in the average temperature to test with.